### PR TITLE
Change the severity from error to info for DMA-/PIO-mode messages.

### DIFF
--- a/drivers/tty/serial/sunplus-uart.c
+++ b/drivers/tty/serial/sunplus-uart.c
@@ -2029,20 +2029,20 @@ static int sunplus_uart_platform_driver_probe_of(struct platform_device *pdev)
 		sunplus_uartdma_rx_binding(pdev->id);
 
 	if (sunplus_uart_ports[pdev->id].uartdma_rx)
-		DBG_ERR("%s's Rx is in DMA mode.\n",
+		dev_info(&pdev->dev, "%s's Rx is in DMA mode.\n",
 			sunplus_uart_ports[pdev->id].name);
 	else
-		DBG_ERR("%s's Rx is in PIO mode.\n",
+		dev_info(&pdev->dev, "%s's Rx is in PIO mode.\n",
 			sunplus_uart_ports[pdev->id].name);
 
 	sunplus_uart_ports[pdev->id].uartdma_tx =
 		sunplus_uartdma_tx_binding(pdev->id);
 
 	if (sunplus_uart_ports[pdev->id].uartdma_tx)
-		DBG_ERR("%s's Tx is in DMA mode.\n",
+		dev_info(&pdev->dev, "%s's Tx is in DMA mode.\n",
 			sunplus_uart_ports[pdev->id].name);
 	else
-		DBG_ERR("%s's Tx is in PIO mode.\n",
+		dev_info(&pdev->dev, "%s's Tx is in PIO mode.\n",
 			sunplus_uart_ports[pdev->id].name);
 
 	ret = uart_add_one_port(&sunplus_uart_driver, port);


### PR DESCRIPTION
This patch changes the severity of messages from error to info, for these messages:

before:
```
[    0.757825] K_TTYS: sp_uart1's Rx is in DMA mode.
[    0.757960] K_TTYS: sp_uart1's Tx is in DMA mode.
[    0.758050] 9c000980.serial: ttyS1 at MMIO 0x9c000980 (irq = 54, base_baud = 1687500) is a sp_uart1
```

after:
```
[    0.764119] ttyS 9c000980.serial: sp_uart1's Rx is in DMA mode.
[    0.764218] ttyS 9c000980.serial: sp_uart1's Tx is in DMA mode.
[    0.764765] 9c000980.serial: ttyS1 at MMIO 0x9c000980 (irq = 54, base_baud = 1687500) is a sp_uart1
```