### PR TITLE
Enable interrupts on GPIO pins.

### DIFF
--- a/drivers/pinctrl/sunplus/sppctl_gpio_ops.c
+++ b/drivers/pinctrl/sunplus/sppctl_gpio_ops.c
@@ -364,9 +364,6 @@ int sppctlgpio_i_map(struct gpio_chip *_c, unsigned int _off)
 	struct sppctlgpio_chip_t *pc = (struct sppctlgpio_chip_t *)gpiochip_get_data(_c);
 	int i;
 
-#if 1
-	return -ENXIO;
-#endif
 	if ( _off < SPPCTL_MUXABLE_MIN || _off > SPPCTL_MUXABLE_MAX) {
 	  KERR(_c->parent, "i_map: %d is not muxable\n", _off);
 	  return -ENXIO;


### PR DESCRIPTION
This patch enables interrupts on GPIO pins.

Before:
```
# ./gpio-event-mon -n gpiochip0 -o 10 -r -f
Failed to issue GPIO_GET_LINE_IOCTL (-6), No such device or address
```

After:
```
# ./gpio-event-mon -n gpiochip0 -o 10 -r -f
Monitoring line 10 on gpiochip0
Initial line value: 1
GPIO EVENT at 25906264427 on line 10 (1|1) falling edge
GPIO EVENT at 26721510723 on line 10 (2|2) falling edge
GPIO EVENT at 26876857871 on line 10 (3|3) falling edge
GPIO EVENT at 27081428167 on line 10 (4|4) falling edge
GPIO EVENT at 27148276537 on line 10 (5|5) falling edge
GPIO EVENT at 27502169722 on line 10 (6|6) falling edge
GPIO EVENT at 27887788167 on line 10 (7|7) falling edge
GPIO EVENT at 27951442759 on line 10 (8|8) rising edge
```