### PR TITLE
Fix SPI

### DIFF
--- a/drivers/spi/spi-sunplus-sp7021.c
+++ b/drivers/spi/spi-sunplus-sp7021.c
@@ -105,7 +105,7 @@ static irqreturn_t sp7021_spi_slave_irq(int irq, void *dev)
 
 	data_status = readl(pspim->s_base + SP7021_DATA_RDY_REG);
 	data_status |= SP7021_SLAVE_CLR_INT;
-	writel(data_status , pspim->s_base + SP7021_DATA_RDY_REG);
+	writel(data_status, pspim->s_base + SP7021_DATA_RDY_REG);
 	complete(&pspim->slave_isr);
 	return IRQ_HANDLED;
 }

--- a/drivers/spi/spi-sunplus-sp7021.c
+++ b/drivers/spi/spi-sunplus-sp7021.c
@@ -411,7 +411,11 @@ static int sp7021_spi_controller_probe(struct platform_device *pdev)
 	struct spi_controller *ctlr;
 	int mode, ret;
 
-	pdev->id = of_alias_get_id(pdev->dev.of_node, "sp_spi");
+	pdev->id = of_alias_get_id(pdev->dev.of_node, "sp-spi");
+	if (pdev->id < 0) {
+		dev_err(dev, "no OF entry\n");
+		return pdev->id;
+	}
 
 	if (device_property_read_bool(dev, "spi-slave"))
 		mode = SP7021_SLAVE_MODE;
@@ -509,6 +513,11 @@ static int sp7021_spi_controller_probe(struct platform_device *pdev)
 		pm_runtime_disable(dev);
 		return dev_err_probe(dev, ret, "spi_register_master fail\n");
 	}
+	if (mode == SP7021_SLAVE_MODE)
+		dev_info(dev, "slave mode\n");
+	else
+		dev_info(dev, "master mode\n");
+
 	return 0;
 }
 


### PR DESCRIPTION
This patch set fixes SPI.

Without it, the kernel crashes as soon as a SPI-write is performed.
With it, SPI writes operate normally.

The first patch fixes probing SPI devices. The alias was changed from sp_spi to sp-spi in commit https://github.com/sunplus-plus1/linux/commit/cd32f01900e0a2392e309340206165b9b6b2dc61 

The second patch manually merges in fixes to interrupt logic done by Dmitry Dvorkin in git@github.com:tibbotech/plus1_kernel.git