### PR TITLE
Fix a compile error in sunplus_wdt.c when building for SP7021

### DIFF
--- a/drivers/watchdog/sunplus_wdt.c
+++ b/drivers/watchdog/sunplus_wdt.c
@@ -96,8 +96,8 @@ static int sp_wdt_ping(struct watchdog_device *wdev)
 {
 	struct sp_wdt_priv *priv = watchdog_get_drvdata(wdev);
 	void __iomem *base = priv->base;
-	void __iomem *base_rst = priv->base_rst;
 #ifdef CONFIG_SOC_SP7350
+	void __iomem *base_rst = priv->base_rst;
 	u32 count_f;
 	u32 count_b;
 	u32 time_f;


### PR DESCRIPTION
This patch fixes a compile error when building for SP7021:

> drivers/watchdog/sunplus_wdt.c:99:33: error: 'struct sp_wdt_priv' has no member named 'base_rst'